### PR TITLE
Fix bold/italic format when a cell is string (not object).

### DIFF
--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -187,7 +187,7 @@ function xlsx(file, options) {
 				var height = options.forcedRowHeight && options.forcedRowHeight[i] >= 0 ? options.forcedRowHeight[i] : options.defaultRowHeight;
 				s += '<row r="' + (i + 1) + '"' + (height >= 0 ? ' customHeight="1" ht="' + height + '"' : '') + ' x14ac:dyDescent="0.25">';
 				while (++j < k) {
-					cell = data[i][j]; val = cell.hasOwnProperty('value') ? cell.value : cell; t = '';
+					cell = data[i][j]; cell = typeof cell === 'string' ? {value: cell} : cell; val = cell.value; t = '';
 					// supported styles: borders, hAlign, formatCode and font style
 					style = {
 						borders: cell.borders || defaultCellBorders,


### PR DESCRIPTION
The code edit makes 'cell' an object before the ibold/italic property
checks are made in the style object assignment below. If 'cell' is
left as a string (pre-edit), then cell.bold/italic are functions,
not undefined as expected. When 'style' is checked later, bold/italic
are mistakenly turned on for such cells.

I looked at adding a test to show this behavior, but would have had to add a great deal of infrastructure. As an alternative, I investigated whether the same change was needed and testable in https://github.com/stephen-hardy/xlsx.js.  That code looks the same, but the case is tested and seems to work. I don't understand why the same issue does not occur.
