### PR TITLE
Allows to directly use js-xlsx to setup cell formats

### DIFF
--- a/lib/node-xlsx.js
+++ b/lib/node-xlsx.js
@@ -18,17 +18,22 @@ function sheet_from_array_of_arrays(data) {
       if(range.s.c > C) range.s.c = C;
       if(range.e.r < R) range.e.r = R;
       if(range.e.c < C) range.e.c = C;
-      var cell = {v: data[R][C] };
+
+      var cell = ((data[R][C] && typeof data[R][C] === 'object')) ? data[R][C] : {v : data[R][C]};
+
       if(cell.v === null) continue;
       var cell_ref = XLSX.utils.encode_cell({c:C,r:R});
 
-      if(typeof cell.v === 'number') cell.t = 'n';
-      else if(typeof cell.v === 'boolean') cell.t = 'b';
-      else if(cell.v instanceof Date) {
-        cell.t = 'n'; cell.z = XLSX.SSF._table[14];
-        cell.v = datenum(cell.v);
+      if (!cell.t) {
+        if (typeof cell.v === 'number') cell.t = 'n';
+        else if (typeof cell.v === 'boolean') cell.t = 'b';
+        else if (cell.v instanceof Date) {
+          cell.t = 'n';
+          cell.z = XLSX.SSF._table[14];
+          cell.v = datenum(cell.v);
+        }
+        else cell.t = 's';
       }
-      else cell.t = 's';
 
       ws[cell_ref] = cell;
     }
@@ -44,6 +49,7 @@ function Workbook() {
 }
 
 module.exports = {
+  XLSX : XLSX,
   parse: function(mixed, options) {
     var ws;
     if(typeof mixed === 'string') ws = XLSX.readFile(mixed, options);

--- a/lib/node-xlsx.js
+++ b/lib/node-xlsx.js
@@ -13,6 +13,9 @@ function sheet_from_array_of_arrays(data) {
   var ws = {};
   var range = {s: {c:10000000, r:10000000}, e: {c:0, r:0}};
   for(var R = 0; R !== data.length; ++R) {
+    if (!data[R]) {
+      continue;
+    }
     for(var C = 0; C !== data[R].length; ++C) {
       if(range.s.r > R) range.s.r = R;
       if(range.s.c > C) range.s.c = C;

--- a/lib/node-xlsx.js
+++ b/lib/node-xlsx.js
@@ -22,7 +22,9 @@ function sheet_from_array_of_arrays(data) {
       if(range.e.r < R) range.e.r = R;
       if(range.e.c < C) range.e.c = C;
 
-      var cell = ((data[R][C] && typeof data[R][C] === 'object')) ? data[R][C] : {v : data[R][C]};
+      var isObject = data[R][C] && typeof data[R][C] === 'object';
+      var isDate = isObject && (data[R][C].v && data[R][C].v instanceof Date);
+      var cell = isObject && !isDate ? data[R][C] : {v : data[R][C]};
 
       if(cell.v === null) continue;
       var cell_ref = XLSX.utils.encode_cell({c:C,r:R});

--- a/test/build.js
+++ b/test/build.js
@@ -14,6 +14,13 @@ var xlsx = require('../lib/node-xlsx');
 module.exports.build = function(assert) {
 
   var fixture = JSON.parse(fs.readFileSync(__dirname + '/fixtures/test.json'));
+
+  fixture[0].data.push([
+    {t : 'n', z : xlsx.XLSX.SSF._table[4], v : 1234567 },
+    {t : 'n', z : xlsx.XLSX.SSF._table[38], v : -1234567 },
+    {t : 'v', v : xlsx.XLSX.SSF.format('$#,##0.00', 1234567) }
+  ]);
+
   var filename = __dirname + '/fixtures/test.xlsx';
   var xlsData;
 


### PR DESCRIPTION
Allow to use XLXS methods/formatters directly if needed.
e.g., to print 123456 formatted as 123,456