### PR TITLE
Added option for ws['!cols'] parameters for column width setting.

### DIFF
--- a/lib/node-xlsx.js
+++ b/lib/node-xlsx.js
@@ -9,7 +9,7 @@ function datenum(v, date1904) {
   return (epoch - new Date(Date.UTC(1899, 11, 30))) / (24 * 60 * 60 * 1000);
 }
 
-function sheet_from_array_of_arrays(data) {
+function sheet_from_array_of_arrays(data, options) {
   var ws = {};
   var range = {s: {c:10000000, r:10000000}, e: {c:0, r:0}};
   for(var R = 0; R !== data.length; ++R) {
@@ -32,6 +32,7 @@ function sheet_from_array_of_arrays(data) {
 
       ws[cell_ref] = cell;
     }
+    if (options['!cols']) ws['!cols'] = options['!cols'];
   }
   if(range.s.c < 10000000) ws['!ref'] = XLSX.utils.encode_range(range);
   return ws;
@@ -61,7 +62,7 @@ module.exports = {
     var wb = new Workbook();
     array.forEach(function(worksheet) {
       var name = worksheet.name || 'Sheet';
-      var data = sheet_from_array_of_arrays(worksheet.data || []);
+      var data = sheet_from_array_of_arrays(worksheet.data, options || [], options);
       wb.SheetNames.push(name);
       wb.Sheets[name] = data;
     });


### PR DESCRIPTION
fixes #25
Now you can pass js-xlsx option '!cols' with column width params, example:
xlsx.build(worksheets,{'!cols':  [ {wch:6},{wch:8},{wch:12}, {wch:14}]})