### PR TITLE
Change the code returns excelData

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,5 @@ export function build(worksheets, options = {}) {
     workBook.Sheets[name] = data;
   });
   const excelData = XLSX.write(workBook, Object.assign({}, defaults, options));
-  if (!excelData) {
-    return false;
-  }
-  return new Buffer(excelData, 'binary');
+  return excelData instanceof Buffer ? excelData : new Buffer(excelData, 'binary');
 }


### PR DESCRIPTION
 Don't need to copy the data buffer when the workbook type is 'buffer'.
 Delete null check code. XLSX.build() doesn't return null but throws an error.