### PR TITLE
Add xlsx build option guide to README: cols

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ const data = [[1, 2, 3], [true, false, null, 'sheetjs'], ['foo', 'bar', new Date
 var buffer = xlsx.build([{name: "mySheetName", data: data}]); // Returns a buffer
 ```
 
+  * Building a xlsx (set column width)
+```js
+import xlsx from 'node-xlsx';
+// Or var xlsx = require('node-xlsx').default;
+
+const data = [[1, 2, 3], [true, false, null, 'sheetjs'], ['foo', 'bar', new Date('2014-02-19T14:30Z'), '0.3'], ['baz', null, 'qux']]
+const option = {'!cols': [{ wch: 6 }, { wch: 7 }, { wch: 10 }, { wch: 20 } ]};
+
+var buffer = xlsx.build([{name: "mySheetName", data: data}], option); // Returns a buffer
+```
+
   * Building a xlsx (spannig multiple rows `A1:A4`)
 ```js
 import xlsx from 'node-xlsx';


### PR DESCRIPTION
cols is very useful option and node-xlsx has already implemented interface to use it.

But because just only merge option is on README file(since we don't have any docs for tihs), I'd like to add copy-paste guide for cols option.