### PR TITLE
Add pass-through support for data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ var buffer = xlsx.build([{name: "myFirstSheet", data: dataSheet1}, {name: "mySec
 _Beware that if you try to merge several times the same cell, your xlsx file will be seen as corrupted._
 
 
+  * Using Primitive Object Notation
+Data values can also be specified in a non-abstracted representation.
+
+Examples:
+```js
+const rowAverage = [[{t:'n', z:10, f:'=AVERAGE(2:2)'}], [1,2,3];
+var buffer = xlsx.build([{name: "Average Formula", data: rowAverage}]);
+```
+
+Refer to [xlsx](https://sheetjs.gitbooks.io) documentation for valid structure and values:
+- Cell Object: https://sheetjs.gitbooks.io/docs/#cell-object
+- Data Types: https://sheetjs.gitbooks.io/docs/#data-types
+- Format: https://sheetjs.gitbooks.io/docs/#number-formats
+
+
+
 ### Troubleshooting
 
 This library requires at lease nodeJS v4. For legacy versions, you can use this workaround before using the lib.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,6 +41,7 @@ const buildSheetFromMatrix = (data, options = {}) => {
         cell.v = buildExcelDate(cell.v);
         cell.z = cell.z || XLSX.SSF._table[14]; // eslint-disable-line no-underscore-dangle
 
+      /* eslint-disable spaced-comment, no-trailing-spaces */
       /***
        * Allows for an non-abstracted representation of the data
        * 
@@ -51,6 +52,7 @@ const buildSheetFromMatrix = (data, options = {}) => {
        * - Data Types: https://sheetjs.gitbooks.io/docs/#data-types
        * - Format: https://sheetjs.gitbooks.io/docs/#number-formats
        **/
+      /* eslint-disable spaced-comment, no-trailing-spaces */
       } else if (isObject(cell.v)) {
         cell.t = cell.v.t;
         cell.f = cell.v.f;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,6 +40,21 @@ const buildSheetFromMatrix = (data, options = {}) => {
         cell.t = 'n';
         cell.v = buildExcelDate(cell.v);
         cell.z = cell.z || XLSX.SSF._table[14]; // eslint-disable-line no-underscore-dangle
+
+      /***
+       * Allows for an non-abstracted representation of the data
+       * 
+       * example: {t:'n', z:10, f:'=AVERAGE(A:A)'}
+       * 
+       * Documentation:
+       * - Cell Object: https://sheetjs.gitbooks.io/docs/#cell-object
+       * - Data Types: https://sheetjs.gitbooks.io/docs/#data-types
+       * - Format: https://sheetjs.gitbooks.io/docs/#number-formats
+       **/
+      } else if (isObject(cell.v)) {
+        cell.t = cell.v.t;
+        cell.f = cell.v.f;
+        cell.z = cell.v.z;
       } else {
         cell.t = 's';
       }

--- a/test/specs/helper.spec.js
+++ b/test/specs/helper.spec.js
@@ -18,5 +18,28 @@ describe('node-xlsx helper', () => {
       expect(typeof buildSheetFromMatrix(notArrayData)).toBe('object');
     });
 
+    describe('with primitive data objects', () => {
+      it('should display data in percentage format with 2-decimal precision', () => {
+        const primitive = [
+          [{t:'n', z:10, f:'=AVERAGE(2:2)'}]
+        ];
+  
+        let sheet = buildSheetFromMatrix(primitive);
+        expect(sheet.A1.t).toBe('n');
+        expect(sheet.A1.f).toBe('=AVERAGE(2:2)');
+        expect(sheet.A1.z).toBe('0.00%');
+      })
+
+      it('should display data in percentage format with 2-decimal precision', () => {
+        const primitive = [
+          [{t:'n', z:4, f:'=SUM(2:2)'}]
+        ];
+  
+        let sheet = buildSheetFromMatrix(primitive);
+        expect(sheet.A1.t).toBe('n');
+        expect(sheet.A1.f).toBe('=SUM(2:2)');
+        expect(sheet.A1.z).toBe('#,##0.00');
+      })      
+    })
   });
 });


### PR DESCRIPTION
### Use Case
Needed a cell to contain a formula that displayed as a decimal with precision.

### Problem
Wasn't able to find documentation, issues, code to support the use-case

### Solution
Added a pass-through option to allow for cells to be specified in any format supported by [xlsx](https://sheetjs.gitbooks.io). While there is likely evidence to support a more prescriptive solution, I wanted to implement a broad solution that enabled users to utilize a more broad array of use-cases supported by xlsx.

* Add pass-through code to helper
* Add and validate unit tests
* Update README with revised documentation