### PR TITLE
feat(update): add !merges property in parsed result.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export function parse(mixed, options = {}) {
   const workSheet = XLSX[isString(mixed) ? 'readFile' : 'read'](mixed, options);
   return Object.keys(workSheet.Sheets).map((name) => {
     const sheet = workSheet.Sheets[name];
-    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false})};
+    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false}), '!merges': sheet["!merges"]};
   });
 }
 


### PR DESCRIPTION
### Use Case
[Support parsing merged cells.#118](https://github.com/mgcrea/node-xlsx/issues/118)

### Problem
Wasn't able to find documentation, issues, code to support the use-case

### Solution
Add !merges property in parsed result to solve the problem of parsing worksheet with merged cells. 