### PR TITLE
fix: add defval in sheet_to_json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export const parse = (mixed, options = {}) => {
   const workSheet = XLSX[isString(mixed) ? 'readFile' : 'read'](mixed, options);
   return Object.keys(workSheet.Sheets).map((name) => {
     const sheet = workSheet.Sheets[name];
-    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false})};
+    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false, defval: null})};
   });
 };
 


### PR DESCRIPTION
if the excel has blank item.when parsed in, the row array can not iterat in undefined item.
like  [1, 2, undefined, undefined, 3]

Array.map() will call 1,2,3 and ignore undefined value. because the item 3 and 4 never assign or has been deleted

add defval in sheet_to_json function can handle this problem