### PR TITLE
add range option for parse method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ export const parse = (mixed, options = {}) => {
   const workSheet = XLSX[isString(mixed) ? 'readFile' : 'read'](mixed, options);
   return Object.keys(workSheet.Sheets).map((name) => {
     const sheet = workSheet.Sheets[name];
-    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false})};
+    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false, range: options.range })};
   });
 };
 


### PR DESCRIPTION
I have a 138kb excel file, but for some reasons, the value of `sheet["!ref"]` is `A1:XFC1048576`, the method `sheet_to_json` in `xlsx` will be in the for loop for a very very long time, it causes CPU in a busy state, and the node thread can't deal with any other requests. Because of this, all the users of this website will got 504.
In fact, the data of this excel file only exists in the area of 'A1:S693', there is no data in othere area.
So, I think we should allow users to pass range option when parse the excel file.

Signed-off-by: lifubang <lifubang@acmcoder.com>