### PR TITLE
add parseMetadata and add range option for parse

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,16 @@ export const parse = (mixed, options = {}) => {
   const workSheet = XLSX[isString(mixed) ? 'readFile' : 'read'](mixed, options);
   return Object.keys(workSheet.Sheets).map((name) => {
     const sheet = workSheet.Sheets[name];
-    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false})};
+    return {name, data: XLSX.utils.sheet_to_json(sheet, {header: 1, raw: options.raw !== false
+      , range: options.range ? options.range[name] : null})};
+  });
+};
+
+export const parseMetadata = (mixed, options = {}) => {
+  const workSheet = XLSX[isString(mixed) ? 'readFile' : 'read'](mixed, options);
+  return Object.keys(workSheet.Sheets).map((name) => {
+    const sheet = workSheet.Sheets[name];
+    return {name, data: sheet["!ref"] ? XLSX.utils.decode_range(sheet["!ref"]) : null };
   });
 };
 
@@ -29,4 +38,4 @@ export const build = (worksheets, options = {}) => {
   return excelData instanceof Buffer ? excelData : bufferFrom(excelData, 'binary');
 };
 
-export default {parse, build};
+export default {parse, parseMetadata, build};

--- a/test/specs/import.spec.js
+++ b/test/specs/import.spec.js
@@ -6,6 +6,6 @@ describe('node-xlsx import', () => {
     expect(typeof XSLX).toBe('object');
   });
   it('should has current keys', () => {
-    expect(Object.keys(XSLX)).toEqual(['parse', 'build']);
+    expect(Object.keys(XSLX)).toEqual(['parse', 'parseMetadata', 'build']);
   });
 });


### PR DESCRIPTION
I have a 138kb excel file, but for some reasons, the value of sheet["!ref"] is A1:XFC1048576, the method sheet_to_json in xlsx will be in the for loop for a very very long time, it causes CPU in a busy state, and the node thread can't deal with any other requests. Because of this, all the users of this website will got 504.
In fact, the data of this excel file only exists in the area of 'A1:S693', there is no data in othere area.
So, I think we should provide a way to allow users can control it, for example allow users to get the exact range size value of each sheet and allow users to pass range option for each sheet when parse the excel file.

Signed-off-by: lifubang <lifubang@acmcoder.com>