### PR TITLE
Convert xlsx to xlsx-republish to allow tracking of most current xlsx…

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "repository": "github:mgcrea/node-xlsx",
   "license": "Apache-2.0",
   "dependencies": {
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    "xlsx-republish": "^0.20.3"
   },
   "devDependencies": {
     "@mgcrea/eslint-config-node": "^0.10.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 import * as fs from "fs";
-import { set_fs } from "xlsx";
+import { set_fs } from "xlsx-republish";
 
 set_fs(fs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   utils,
   write,
   WritingOptions,
-} from "xlsx";
+} from "xlsx-republish";
 import "./config";
 import { isString } from "./helpers";
 import { WorkBook } from "./workbook";

--- a/src/workbook.ts
+++ b/src/workbook.ts
@@ -1,4 +1,4 @@
-import type { WorkSheet, WorkBook as XLSXWorkBook } from "xlsx";
+import type { WorkSheet, WorkBook as XLSXWorkBook } from "xlsx-republish";
 
 export class WorkBook implements XLSXWorkBook {
   Sheets: Record<string, WorkSheet> = {};

--- a/test/specs/parse.spec.ts
+++ b/test/specs/parse.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import xlsx from "xlsx";
+import xlsx from "xlsx-republish";
 import { parse as parseXSLX } from "../../src";
 import { readBufferFixture, readFixture } from "../utils";
 


### PR DESCRIPTION
… package

This allows the library to use xlsx-republish, which tracks the most current version of sheetJS while still maintaining the connection to NPM.   Sheet JS no longer publishes to NPM, and this causes the version to get out of date and miss security updates. That is how I found this issue.